### PR TITLE
[♻️Refactor] ALB 헬스 체크 에러

### DIFF
--- a/src/main/java/com/nexerp/global/config/SecurityConfig.java
+++ b/src/main/java/com/nexerp/global/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
         .requestMatchers("/member/signup").permitAll()
         .requestMatchers("/member/login").permitAll()
         .requestMatchers("/member/reissue").permitAll()
+        .requestMatchers("/health").permitAll()
         .requestMatchers("/swagger-ui/**").permitAll()
         .requestMatchers("/v3/api-docs/**").permitAll()
 

--- a/src/main/java/com/nexerp/global/controller/HealthCheckController.java
+++ b/src/main/java/com/nexerp/global/controller/HealthCheckController.java
@@ -1,0 +1,15 @@
+package com.nexerp.global.controller;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Hidden
+@RestController
+public class HealthCheckController {
+
+  @GetMapping("/health")
+  public String healthCheck() {
+    return "UP"; // ALB가 이 문자열과 200 OK를 받으면 정상으로 판단함
+  }
+}

--- a/src/main/java/com/nexerp/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/nexerp/global/security/jwt/JwtAuthenticationFilter.java
@@ -47,6 +47,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     if (path.startsWith("/member/signup") ||
       path.startsWith("/member/login") ||
       path.startsWith("/member/reissue") ||
+      path.startsWith("/health") ||
       path.startsWith("/swagger-ui") ||
       path.startsWith("/v3/api-docs")) {
       filterChain.doFilter(request, response);


### PR DESCRIPTION
<!-- PR 제목 예시
이슈와 같은 형식으로 작성
[PR 유형] PR 내용
ex) [Feature] 깃허브 초기 세팅
-->

### ⛓️‍💥 Issue Number
<!---- 목적 -->
<!---- Resolves: #(Isuue Number) -->
- close #129 

  <br/>

### 🔎 Summary
<!---- 변경된 내용에 대해 자세히 설명해주세요. -->
## 문제 발생 이유 및 해결 과정
docker log 호출 시 일정 시점부터 계속해서 테스트 컨트롤러 에러가 발생하는 것을 확인했고, 이는 프론트 호출이 아닌, alb 헬스체크 프로토콜 설정으로 되어 있었던 /test 컨트롤러가 삭제되면서 자동으로 발생한 것으로 확인되었습니다.

<img width="1722" height="841" alt="image" src="https://github.com/user-attachments/assets/256654be-781d-4416-8fdc-08e3bc875660" />

이는 단순 헬스체크 실패뿐만 아니라, SSL을 인증을 거친 후에 암호화를 풀고 상태 검사를 거칠 때 ALB가 /test 없기 때문에 서버가 '정상'임에도 불구하고 '비정상'으로 판단되어 헬스체크용 api를 호출 시에 cloudwatch 상 500 에러로 잡혔을 것입니다.

<img width="416" height="313" alt="image" src="https://github.com/user-attachments/assets/23195ab7-4527-486e-aaea-5bc4fededdec" />

다행히 서버 구동 자체에는 문제가 없었으나, 만약 오토 스케일링까지 적용했더라면 서버가 강제 종료되었을 것입니다.

<img width="820" height="307" alt="image" src="https://github.com/user-attachments/assets/b42e8f53-da88-4685-9653-f930e28da470" />

따라서, 헬스체크용 API를 만들어서 적용 변경했습니다.

### ✅ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, git template 수정)
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제
 
<br/>

### ✅ PR 체크 리스트
- PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 리뷰어 설정을 했나요?
- [x] Lables를 설정했나요?
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
- [x] test workflow가 정상적으로 작동했습니다.
- [x] 병합 위치가 올바른 브랜치인지 확인하셨나요?