### PR TITLE
[✨Feature] 트랜잭션 설정(@Transactional) 최적화 및 성능 검증

### DIFF
--- a/src/main/java/com/nexerp/domain/company/service/CompanyService.java
+++ b/src/main/java/com/nexerp/domain/company/service/CompanyService.java
@@ -49,7 +49,6 @@ public class CompanyService {
   }
 
   // keyword=""의 경우 전체 리스트 / 없는 키워드는 빈 배열
-  @Transactional(readOnly = true)
   public List<CompanySearchResponse> searchCompaniesByName(String keyword) {
     List<Company> companies = companyRepository
       .findByNameContainingIgnoreCaseOrderByNameAsc(keyword);


### PR DESCRIPTION
<!-- PR 제목 예시
이슈와 같은 형식으로 작성
[PR 유형] PR 내용
ex) [Feature] 깃허브 초기 세팅
-->

### ⛓️‍💥 Issue Number
<!---- 목적 -->
<!---- Resolves: #(Isuue Number) -->
- close #137 

  <br/>

### 🔎 Summary
<!---- 변경된 내용에 대해 자세히 설명해주세요. -->
조회 전용 API의 @Transactional(readonly = true) 적용 여부에 따른 성능 트레이드 오프를 분석하기 위해서 크게 세 가지 단계를 거쳤습니다. 

1. [**숨은 쿼리 및 세션 제어 분석**](#1)
2. [**부하 테스트 (k6 기반) 및 정량적 비교를 통한 기준 수립**](#2)
3. [**기준에 따른 적용 대상 선별 해보기 + 최종 결론**](#3)

<div id="1"></div>

## 1단계: 숨은 쿼리 찾기 및 세션 제어 분석
Spring Data JPA의 로그에서 보이지 않는 세션 제어 쿼리를 찾기 위해 다음과 같은 의존성을 추가해서 직원 가입 상태 조회 api를 호출해보았어요.

`implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0’`
```
Hibernate: 
    select
        m1_0.member_id,
        m1_0.company_id,
        m1_0.member_department,
        m1_0.member_email,
        m1_0.member_join_date,
        m1_0.member_join_request_date,
        m1_0.member_login_id,
        m1_0.member_name,
        m1_0.member_password,
        m1_0.inventory_role,
        m1_0.logistics_role,
        m1_0.management_role,
        m1_0.member_position,
        m1_0.member_request_status,
        m1_0.token_version 
    from
        member m1_0 
    where
        m1_0.company_id=? 
        and m1_0.member_id<>? 
    order by
        m1_0.member_join_request_date
2026-01-29T16:37:09.189+09:00  INFO 20692 --- [nio-3006-exec-2] p6spy                                    : #1769672229189 | took 148ms | statement | connection 12| url jdbc:mysql://silkroad-db.cvays0easq0o.ap-southeast-2.rds.amazonaws.com:3306/nexerp_db?serverTimezone=Asia/Seoul
select m1_0.member_id,m1_0.company_id,m1_0.member_department,m1_0.member_email,m1_0.member_join_date,m1_0.member_join_request_date,m1_0.member_login_id,m1_0.member_name,m1_0.member_password,m1_0.inventory_role,m1_0.logistics_role,m1_0.management_role,m1_0.member_position,m1_0.member_request_status,m1_0.token_version from member m1_0 where m1_0.company_id=? and m1_0.member_id<>? order by m1_0.member_join_request_date
select m1_0.member_id,m1_0.company_id,m1_0.member_department,m1_0.member_email,m1_0.member_join_date,m1_0.member_join_request_date,m1_0.member_login_id,m1_0.member_name,m1_0.member_password,m1_0.inventory_role,m1_0.logistics_role,m1_0.management_role,m1_0.member_position,m1_0.member_request_status,m1_0.token_version from member m1_0 where m1_0.company_id=1 and m1_0.member_id<>1 order by m1_0.member_join_request_date;
2026-01-29T16:37:09.349+09:00  INFO 20692 --- [nio-3006-exec-2] p6spy    
```

P6Spy를 통해 실시간 쿼리 패킷을 분석한 결과, 우리 환경(MYSQL/RDS)에서는 `readOnly = true`로 인한 추가 세션 제어 쿼리(Overhead)가 발생하지 않음을 확인했습니다.

> 다만, `@Transactional(=readOnly)`를 제외하고 호출한 경우 개별 쿼리들의 속도가 평균적으로 더 빠르긴 했습니다.

뭔가 이상함을 느껴서 RDS db 단에서의 general log 확인을 하면 좋겠다고 생각했습니다. (참고 레퍼런스 중 카카오 테크 개발자분께서도 general-log-query를 통해 문제를 확인했습니다.)

이를 위해 rds 파라미터 그룹을 생성하였고, (기존의 default 그룹으로는 로그 분석이 불가능합니다.)

<img width="911" height="219" alt="image" src="https://github.com/user-attachments/assets/e44bb4d0-51cd-4d2b-96ee-b98ba629a0fb" />
<img width="935" height="279" alt="image" src="https://github.com/user-attachments/assets/4de96544-0eec-4664-8223-f7c2848fabde" />

파라미터 그룹 설정을 통해 로그가 제대로 찍히고 있는지 우선 확인했습니다.

<img width="538" height="218" alt="image" src="https://github.com/user-attachments/assets/515ee3bf-e48a-4623-83c6-4655279d2564" />


<br>


그 다음 테스트를 위해 기존 로그를 비운 후에 argument를 char로 변환하여 query_text로 치환했어요.
```
SELECT event_time, thread_id, CAST(argument AS CHAR) as query_text
FROM mysql.general_log
WHERE argument NOT LIKE '%mysql.general_log%'
AND argument NOT LIKE 'SELECT 1'
ORDER BY event_time DESC
LIMIT 50;
```

확인 결과, Transactional을 적용한 경우 나가는 쿼리의 개수가 더 적었습니다. 

<img width="648" height="318" alt="image" src="https://github.com/user-attachments/assets/f0a2379d-7ee6-4104-b293-2c1bd65e64d9" />

이 사진은 적용하지 않았을 때로 총 13개의 쿼리가 나가고 있고 (thread_id = 252)

<img width="652" height="283" alt="image" src="https://github.com/user-attachments/assets/4739fb4c-7f64-4329-a0f6-1d5031417068" />

적용한 경우 (thread_id = 270) 10개의 쿼리로 3개의 쿼리가 덜 나가고 있었어요.

그래서 쿼리 3개의 차이가 왜 나왔을지 기술적 원인을 고민해봤습니다.

### 트랜잭션 파편화와 번들링
로그상으로 확인된 13개 (스레드 252)와 10개 (스레드 270)의 결정적 차이는 트랜잭션 관리 범위에 있었습니다.

사진에 나온 쿼리를 쭉 확인해보면

- 13개 쿼리 (파편화 모드) :서비스 계층에 `@Transactional`이 없으면, 각 리포지토리 메서드 (`findById`, `findByCompanyId`)를 실행할 때마다 별도의 트랜잭션이 생성되고, 이로 인해 각 조회 쿼리 앞뒤로 `SET autocommit = 0, commit, SET autocommit = 1` 같은 쿼리들이 중복해서 발생하여 총 개수가 늘어난 것입니다.
- 10개 쿼리 (번들링 모드): 하지만 `@Transactional`을 사용하면 여러 개의 조회 쿼리를 하나의 트랜잭션으로 묶어주니까, 결과적으로 트랜잭션을 시작하고 닫는 행정 쿼리가 단 한 번만 발생하고 그 안에 비즈니스 쿼리들이 담기기 때문에 전체 쿼리 수가 3개 절감된 것입니다.

### 그렇다면 왜 Transactional을 적용하지 않은 경우가 더 빨랐을까?
기술적인 이유가 있습니다.

|  구분  |              `@Transactional(readonly = true) 적용`             | `@Transactional(readonly = true) 미적용` |
|:------:|:----------------------------:|:------------:|
| 쿼리 수 | 10개 (번들링되어 효율적) | 13개 (파편화되어 발생) |
| 자바 연산 | 무거움(프로시 생성, 트랜잭션 매니저 가동) | 가벼움 (일반 메서드 호출) |
| 응답 속도 | 상대적으로 느림 | 상대적으로 빠름 (평균 10ms 정도) |

왜 이런 결과가 나온 걸까라고 생각을 해보면, 단순 조회 API에서는 DB 쿼리 3개 날리는 네트워크 비용보다, 스프링 프레임워크가 트랜잭션이라는 거대한 인프라를 준비하고 관리하는 행정 비용이 더 컸기 때문입니다.

> 즉, 프레임워크의 오버헤드보다 가벼웠던 것.

### 그래서 Transactional(readonly) 적용해야 할까 말아야 할까.
카카오페이 글을 참고하면 이런 글을 남겨 두었더라고요. "Transactional 미 적용 시 select 쿼리가 2~3배 증가되어 DB  사용 성능이 좋아졌다. " 이 말이 결국 한 번의 요청에 쿼리가 더 나갔다는 뜻이 아니라, 단위 시간당 DB가 처리할 수 있는 전체 쿼리의 양이 늘어났다는 뜻이 되는 겁니다.

- 트랜잭션이 있을 때: DB는 진짜 데이터 조회뿐 아니라, "나 읽기 전용으로 바꿀게", "오토커밋 끌게", "이제 커밋할게" 같은 부수적 명령을 묶어서 처리하느라 바쁘다는 것이고.
- 트랜잭션이 없을 때: 이런 부서적 명령이 사라지니까, DB가 오직 데이터를 찾는 본업(SELECT)에만 집중할 수 있다. 즉, 전체적으로 처리 능력이 좋아진다.

따라서, readOnly를 다 빼기 보다는 성능이 최우선인 단순 조회 API에 한해서만 빼는 것을 고려하는 게 좋다고 생각했습니다. 하지만 데이터 일관성 및 정합성, 지연 로딩이 치명적인 경우는 유지하는 게 좋은 데요. 예시는 다음과 같습니다.

### 데이터 일관성 예시
NexERP API를 기준으로 했을 때, 재고에서 입출고 이력 조회 API의 경우에 입고 이력과 출하 이력을 조회하는 과정에서 1번 업무의 이력을 조회하고, 2번 업무의 이력을 조회할 때 입출고에 따라 전체 합계가 맞지 않는 Phantom Read 현상이 발생할 가능성이 있습니다. 이 때, readOnly = true는 조회 시작 지점의 스냅샷을 유지하여 데이터 정합성을 보장하기 때문에 반드시 필요하죠.

### 지연 로딩 예시
예를 들어, 출하 물품 상세 조회 시, 출하 엔티티를 타서 연관된 물품 리스트에 접근하는데, JPA에서 연관 관계는 보통 지연 로딩으로 설정을 하니까, 이 때 트랜잭션 범위 밖에서 리스트에 접근하면 LazyInitializationException이 발생하며 서버가 터질 수 있습니다. 이 경우에도 Transactional은 이 연관관계를 다 읽을 때까지 DB 세션을 열어두는 역할을 하기에 필요합니다.

<br>

<div id="2"></div>

## 2단계: 정량적 트레이드오프 비교: K6 테스트
단일 요청에서 10ms 정도의 이득이 대규모 부하와 고레이턴시 환경에서 전체 실행 속도에 얼마나 영향을 주는지 테스트가 필요하다고 생각했습니다. 결국 서버의 개선을 위함이니까요!

부하 테스트를 위해 K6를 설치한 후 로컬에서 테스트 해보았습니다. (dashboard의 경우 그라파나를 설치하여 연결해도 되지만, k6 자체적으로 web-dashboard를 포함해서 실행할 수 있더라고요!)

`k6 run --out 'web-dashboard=export=report.html' test.js`

우선 기본 테스트는 가장 연관관계가 적고, 토큰 인증도 필요하지 않은 회사 검색 API로 진행했습니다.
```
import http from 'k6/http';
import { check, sleep } from 'k6';

export const options = {
    // 동시 접속자 100명으로 30초간 테스트
    vus: 100,
    duration: '30s',
    thresholds: {
        // 시드니 리전임을 고려하여 p(95) 기준을 1500ms로 넉넉히 잡되,
        // 두 설정 간의 '상대적 차이'를 보는 것이 핵심입니다.
        http_req_duration: ['p(95)<1500'],
    },
};

export default function () {
    // 인증이 필요 없는 공용 기업 검색 API
    const url = 'http://127.0.0.1:3006/companies?keyword=';

    const res = http.get(url);

    check(res, {
        'is status 200': (r) => r.status === 200,
    });

    // 유저 한 명이 검색 후 결과를 훑어보는 시간을 1초로 가정
    sleep(1);
}
```

> 동시 접속자 100명을 기준으로 총 세 번씩 테스트 했으며, 총 응답 시간 (100명에 대한 응답 시간의 총합)이 1.7배 정도 차이가 났습니다. 

`Transactional(readonly=true)`를 제거한 경우에는 10.6s 10.24 10.27s 제거하지 않은 경우에는 17.82s 17.53s 17.07s으로 계산이 필요하지 않을 정도로 차이가 났어요.

이 결과의 차이를 K6 대시보드를 통해 좀 더 명확히 살펴보았습니다.

제거한 경우에는 아래와 같이 초기 요청 이후에 파란 선 (응답 시간) 이 일정하게 유지되고 있습니다.
<img width="1875" height="807" alt="image" src="https://github.com/user-attachments/assets/aa2e52e0-6da5-4813-b78b-a5069c130a2c" />

하지만 제거하지 않은 경우에는 비교적 요동치는 그래프로서 커넥션을 얻지 못한 유저들의 시간이 누적되고 있었습니다.

<img width="1882" height="789" alt="image" src="https://github.com/user-attachments/assets/42c3ce70-d2b1-49d4-abd2-571c8e50e0eb" />

이러한 비교를 바탕으로 차이의 근거를 도출했어요.

> "커넥션 점유 시간과 고레이턴시의 악순환"

### 트랜잭션을 적용한 경우
트랜잭션이 걸리면 메서드가 시작될 때 DB 커넥션을 획득하고, 메서드가 완전히 끝날 때까지 잡고 놔주지를 않게 됩니다. 그런데, 현재 저희는 1단계에서 확인한대로 쿼리 하나에 보통 140ms 정도 걸리는데, 이를 처리하는 동안 커넥션이 묶여 있으니까, 100명이 동시에 요청을 쏘면 한정된 커넥션을 얻기 위해 (예를 들어 10명이면) 나머지 (90명)는 무한 대기 상태에 빠지고, 이것이 응답 속도를 7초나 더 누적되게 만든 것입니다.

### 트랜잭션을 제거한 경우
트랜잭션 범위가 없으므로, 개별 쿼리가 실행될 때만 커넥션을 잠깐 빌렸다가 즉시 반납합니다. 즉 쿼리가 파편화되니까 네트워크 왕복 자체는 늘어나지만, 커넥션을 짧게 쓰고, 바로 돌려주기 때문에 커넥션 회전율이 비약적으로 상승하는 것이죠. 덕분에 100명의 유저가 대기 없이 빠르게 서비스를 이용할 수 있어서 더 짧은 응답 속도를 유지할 수 있었던 겁니다!

이 데이터를 바탕으로 정량적 트레이드 오프 비교는 다음과 같았어요.
 |  지표 (100 VUs)  |              @Transactional(readonly = true) 적용             | @Transactional(readonly = true) 미적용 | 개선 결과 |
|:------:|:----------------------------:|:------------:|:------------------:|
| 평균 응답 시간 | 약 17.47s | 약 10.37s | 약 7.1s (40%)  단축|
| 최고 응답 시간 | 17.82s | 10.6s | 일관된 성능 향상 |
| 처리 효율 | 상대적 낮음 | 약 1.7배 높음 | 커넥션 회전율 증가 |

따라서 ps6py와 mysql의 쿼리 로그, 블로그 레퍼런스를 통해 얻은 결론처럼 테이블 간 관계가 복잡하지 않은 단순 조회 API에서는 Transactional(readonly=true)가 오히려 성능을 떨어뜨릴 수 있다는 점을 알게 되었습니다.

<br>

<div id="3"></div>

## 3단계: 적용 여부
이제 이를 기반으로 어떤 API에 빼고, 유지해야 할지 고민을 해보았습니다.
우선 세 가지 기준을 선정했어요.

### 지연 로딩 관계가 있는가
- 삭제 가능한 경우
   - 엔티티가 아닌 DTO로 직접 조회 (예: select new com.nexerp.MemberDto(...)) DTO로 뽑는 순간 이미 데이터가 채워졌으므로, 세션이 닫혀도 무관. -> 이건 저희 api에는 거의 없었습니다. 
   - 엔티티를 조회하더라도, 연관관계 등에 아예 접근하지 않는 단순 단건 조회 API (방금 보았던 회사 검색이 대표적)
- 유지가 필요한 경우:
   - 조회된 엔티티를 반환하고, 서비스 레이어 밖에서 `entity.getItems()`처럼 연관 객체를 호출해야 하는 경우, 이때는 트랜잭션이 없으면 당연히 LazyInitializationException이 발생합니다. 

### 데이터 일관성이 필요한 코드인가
하나의 API안에서 두 번 이상의 조회가 일어날 때입니다.
- 삭제 가능한 경우
   - 조회 쿼리가 딱 1개인 API
   - 여러 번 조회하더라도, 데이터가 그 찰나에 변해서 결과가 조금 달라져도 비즈니스에 큰 지장이 없는 단순 현황 조회
- 유지가 필요한 경우:
   - 재고 실시간 입출하 이력 등 숫자 하나가 민감한 로직 

### 비즈니스 중요도와 트래픽
이번에 보신 것처럼 커넥션 회전율이 가장 중요할 때를 골라야 했습니다.
- 삭제 가능한 경우:
   - 단순 기업 검색 등 사용자가 자주 접속하고 데이터가 방대한 퍼블릭 API
- 유지가 필요한 경우:
   - 입고 업무 상세 조회 로직처럼 데이터의 정확도가 훨씬 중요한 API

저는 위 세 가지 기준을 기반으로 각 api 별 테스트를 통해 적용 여부를 결정하려고 했습니다.
가입 상태, 권한, 관리자, 물품 조회와 같이 서비스 내부에서 그나마 단순한 api로 테스트를 했으나, 7초 이상의 차이가 났던 회사 검색과는 달리 차이가 거의 없거나, 큰 차이가 나지 않았어요.

> 가입 상태: 0.2초 / 권한: 0.6초 / 물품 및 관리자 조회: 차이 X

회사 조회는 토큰 조차도 필요하지 않고, 키워드 기반의 단순 쿼리입니다. 특정 id를 통해서 db를 여러 번 타지 않습니다. 하지만, 물품 조회를 예로 들더라도, `memberRepostory.findById `1번 조회, 그 후 `itemRepository.search...` 2번 조회 

로직 내부에서 DB를 여러 번 탈수록, 커넥션을 열고 닫는 행위 자체가 고레이턴시 환경에서는 새로운 지연($RTT \times N$)을 만듭니다. 즉, 커넥션을 반납해도 다시 잡는 데 드는 시간 때문에 트랜잭션 유지 시의 안정성 이득이 더 큼을 확인했습니다.

그래서 조회 로직 내에서 DB를 여러 번 타는 API(물품 조회 등)는 트랜잭션을 제거하더라도 커넥션을 다시 잡는 데 드는 시간 때문에 성능 이득이 상쇄됩니다. `따라서 단일 쿼리로 종료되는 고트래픽 API(회사 검색)`에 한해서만 선별적 최적화를 진행하여 안정성과 성능을 동시에 확보했습니다.

또한, 나머지 API의 경우 데이터 정합성과 지연 로딩 방어를 고려하여 유지하는 것으로 결정했습니다.

> NexERP의 대부분의 조회 API가 위 API들보다 복잡한 데 여기서 역전이 일어나거나, 차이가 미미한 경우 더더욱 고민할 필요가 없을 거라고 결론을 내렸습니다. 


  <br/>

### ✅ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, git template 수정)
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제
 
<br/>

### ✅ PR 체크 리스트
- PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 리뷰어 설정을 했나요?
- [x] Lables를 설정했나요?
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
- [x] test workflow가 정상적으로 작동했습니다.
- [x] 병합 위치가 올바른 브랜치인지 확인하셨나요?

  <