### PR TITLE
[✨Feature] 비동기 처리 성능 / S3 업로드 성능 개선

### DIFF
--- a/src/main/java/com/nexerp/domain/analytics/application/AnalyticsExportOrchestrator.java
+++ b/src/main/java/com/nexerp/domain/analytics/application/AnalyticsExportOrchestrator.java
@@ -8,14 +8,10 @@ import com.nexerp.domain.analytics.infra.storage.LocalTmpStorage;
 import com.nexerp.domain.analytics.infra.storage.S3Storage;
 import com.nexerp.domain.analytics.port.CsvWriterPort;
 import com.nexerp.domain.analytics.port.ExtractorPort;
-import com.nexerp.domain.analytics.port.StoragePort;
-
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
@@ -25,13 +21,9 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-
-import javax.sql.DataSource;
 
 @Slf4j
 @Service
@@ -105,8 +97,6 @@ public class AnalyticsExportOrchestrator {
       // 전체 성공 시 통과, 하나라도 실패 시 예외가 여기서 터짐
       race.join(); // 1.모든 로컬 파일 생성 완료 대기
 
-      log.info("[AnalyticsExport] 로컬 생성 완료. S3 업로드 및 원자적 이동 시작.");
-
       // 2. S3 업로드 (하나라도 실패 시 예외 처리)
       uploadAllToS3(createdFinalFiles, createdS3Keys);
 
@@ -120,7 +110,8 @@ public class AnalyticsExportOrchestrator {
       return results;
 
     } catch (Exception e) {
-      Throwable cause = (e instanceof CompletionException) ? e.getCause() : e; // CompletionException, IOException 등을 모두 처리
+      Throwable cause = (e instanceof CompletionException) ? e.getCause()
+        : e; // CompletionException, IOException 등을 모두 처리
       log.error("[AnalyticsExport] FAIL-FAST triggered. Export stopped.", cause);
 
       //나머지 스레드 모두 중지
@@ -134,17 +125,20 @@ public class AnalyticsExportOrchestrator {
   }
 
   /**
-   *  모든 파일을 S3로 업로드. 하나라도 실패하면 예외 발생
+   * 모든 파일을 S3로 업로드. 하나라도 실패하면 예외 발생
    */
-  private void uploadAllToS3(List<String> localPaths, List<String> createdS3Keys) throws IOException {
+  private void uploadAllToS3(List<String> localPaths, List<String> createdS3Keys)
+    throws IOException {
+
     for (String localPath : localPaths) {
       String fileName = Path.of(localPath).getFileName().toString();
       String s3Key = s3Storage.resolve(fileName);
 
-      try (OutputStream s30s = s3Storage.openOutputStream(s3Key)) {
-        Files.copy(Path.of(localPath), s30s);
+      try {
+        s3Storage.uploadFile(localPath, s3Key);
+
         createdS3Keys.add(s3Key); // 성공 기록
-        log.info("[S3Upload] Success: {}", s3Key);
+
       } catch (Exception e) {
         throw new IOException("S3 업로드 실패: " + fileName, e);
       }
@@ -202,6 +196,7 @@ public class AnalyticsExportOrchestrator {
     // 로컬 데이터 삭제
     cleanupLocalFiles(localFiles);
   }
+
   /**
    * 실패 시 이미 만들어진 파일들을 정리
    */
@@ -209,7 +204,6 @@ public class AnalyticsExportOrchestrator {
     for (String path : createdFinalFiles) {
       try {
         storage.deleteIfExists(path);
-        log.info("[AnalyticsExport] cleanup deleted file={}", path);
       } catch (Exception e) {
         log.warn("[AnalyticsExport] cleanup failed file={}", path, e);
       }

--- a/src/main/java/com/nexerp/domain/analytics/infra/storage/S3Storage.java
+++ b/src/main/java/com/nexerp/domain/analytics/infra/storage/S3Storage.java
@@ -2,20 +2,24 @@ package com.nexerp.domain.analytics.infra.storage;
 
 import com.nexerp.domain.analytics.config.AnalyticsExportProperties;
 import com.nexerp.domain.analytics.port.StoragePort;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.*;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 @Slf4j
 @Component
@@ -43,20 +47,18 @@ public class S3Storage implements StoragePort {
     return finalPath + ".tmp-" + UUID.randomUUID();
   }
 
-  @Override
-  public OutputStream openOutputStream(String fullPath) throws IOException {
-    return new ByteArrayOutputStream() {
-      @Override
-      public void close() throws IOException {
-        super.close();
-        byte[] bytes = toByteArray();
-        s3Client.putObject(PutObjectRequest.builder()
+  public void uploadFile(String fullPath, String key) {
+    try {
+      s3Client.putObject(PutObjectRequest.builder()
           .bucket(props.s3Bucket())
-          .key(fullPath)
-          .build(), RequestBody.fromBytes(bytes));
-        log.info("[S3Storage] Uploaded to S3: {}", fullPath);
-      }
-    };
+          .key(key)
+          .build(),
+        RequestBody.fromFile(Path.of(fullPath)) // 파일 객체를 직접 전달 (스트리밍)
+      );
+      log.info("[S3Storage] Uploaded to S3: {}", fullPath);
+    } catch (Exception e) {
+      throw new RuntimeException("S3 파일 업로드 실패: " + key, e);
+    }
   }
 
   @Override

--- a/src/main/java/com/nexerp/domain/analytics/port/StoragePort.java
+++ b/src/main/java/com/nexerp/domain/analytics/port/StoragePort.java
@@ -1,7 +1,6 @@
 package com.nexerp.domain.analytics.port;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.List;
 
 // 파일이 저장될 공간(물리적 위치)을 관리하는 규칙
@@ -12,8 +11,6 @@ public interface StoragePort {
   String resolve(String fileName);
 
   String resolveTemp(String finalPath);
-
-  OutputStream openOutputStream(String tmpPath) throws IOException;
 
   void moveAtomic(String tmpPath, String finalPath) throws IOException;
 

--- a/src/test/java/com/nexerp/AnalyticsExportIntegrationTest.java
+++ b/src/test/java/com/nexerp/AnalyticsExportIntegrationTest.java
@@ -2,17 +2,24 @@ package com.nexerp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 import com.nexerp.domain.analytics.application.AnalyticsExportOrchestrator;
 import com.nexerp.domain.analytics.application.AnalyticsExportOrchestrator.ExportResult;
+import com.nexerp.domain.analytics.config.AnalyticsExportProperties;
 import com.nexerp.domain.analytics.domain.ExportFileName;
 import com.nexerp.domain.analytics.domain.ExportTable;
+import com.nexerp.domain.analytics.infra.storage.LocalTmpStorage;
+import com.nexerp.domain.analytics.infra.storage.S3Storage;
 import com.nexerp.domain.analytics.port.StoragePort;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +28,8 @@ import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 
 @ActiveProfiles("local")
 // 저장 경로 지정
@@ -37,64 +46,47 @@ class AnalyticsExportIntegrationTest {
   @Autowired
   private StoragePort storage;
 
-//  @AfterEach
-//  void cleanup() throws IOException {
-//    if (generated != null) {
-//      Files.deleteIfExists(generated);
-//    }
-//  }
+  @Autowired
+  private LocalTmpStorage localStorage;
+  @Autowired
+  private S3Storage s3Storage;
 
-  @Test
-  @DisplayName("모든 등록된 테이블을 병렬로 추출하고 파일 내용과 행 개수를 검증한다")
-  void export_all_tables_parallel_verifies_content() throws IOException {
-    // Given
-    System.out.println("### ALL EXPORT TEST START ###");
-    LocalDate targetDate = LocalDate.now();
+  @Autowired
+  private AnalyticsExportProperties props;
+  @Autowired
+  private S3Client s3Client;
 
-    // When
-    // (1) 병렬 추출 실행
-    Map<ExportTable, ExportResult> results = orchestrator.exportAllFailFastParallel(targetDate);
+  private Map<ExportTable, ExportResult> lastResults;
 
-    // Then
-    assertThat(results).isNotEmpty();
-    System.out.println("Extracted Tables Count: " + results.size());
-
-    for (ExportResult result : results.values()) {
-      // (2) ExportResult에 path가 없으므로 storage를 통해 파일 경로를 다시 계산합니다.
-      String fileName = ExportFileName.of(result.table().filePrefix(), result.date()).toFileName();
-      String fullPathStr = storage.resolve(fileName);
-
-      // 4. 검증을 위해 Path 객체로 변환합니다.
-      Path generatedPath = Path.of(fullPathStr);
-
-      // 1. 파일이 실제로 존재하는지 확인
-      assertThat(Files.exists(generatedPath))
-        .as("파일이 생성되지 않았습니다: %s", generatedPath)
-        .isTrue();
-
-      // 2. 파일 내용 읽기
-      List<String> lines = Files.readAllLines(generatedPath);
-
-      // 3. 최소한 헤더(1줄)는 존재해야 함
-      assertThat(lines.size())
-        .as("%s 테이블의 파일에 데이터가 부족합니다", result.table())
-        .isGreaterThanOrEqualTo(1);
-
-      // 4. (파일 줄 수 - 1)이 결과 리포트의 rowCount와 일치하는지 확인
-      long fileDataRowCount = lines.size() - 1;
-      assertThat(fileDataRowCount)
-        .as("%s 테이블의 DB 추출 건수와 파일 기록 건수가 다릅니다", result.table())
-        .isEqualTo(result.rowCount());
-
-      System.out.printf("[%s] 파일명: %s, 건수: %d%n",
-        result.table(), generatedPath.getFileName(), result.rowCount());
+  // 운영 S3에는 로컬 DB의 테스트 CSV가 적재되지 않도록 AfterEach를 통해 제거
+  @AfterEach
+  void cleanup() {
+    if (lastResults != null) {
+      lastResults.values().forEach(r -> {
+        String fileName = ExportFileName.of(r.table().filePrefix(), r.date()).toFileName();
+        String key = s3Storage.resolve(fileName);
+        try {
+          s3Storage.deleteIfExists(key);
+        } catch (Exception ignored) {
+        }
+      });
     }
 
-    System.out.println("### ALL EXPORT TEST SUCCESS ###");
+    // Local cleanup: 남아있을 수 있는 파일 제거(성공 시엔 원래 없어야 정상)
+    try {
+      Files.createDirectories(Path.of(props.localPath()));
+      Files.list(Path.of(props.localPath())).forEach(p -> {
+        try {
+          Files.deleteIfExists(p);
+        } catch (Exception ignored) {
+        }
+      });
+    } catch (Exception ignored) {
+    }
   }
 
   @Test
-  void all_exports_S3_upload_test() throws IOException{
+  void all_exports_S3_upload_test() throws IOException {
     // Given
     LocalDate testDate = LocalDate.now().minusDays(1);
 
@@ -119,4 +111,77 @@ class AnalyticsExportIntegrationTest {
       System.out.println("[S3 Verification Success] Found Key: " + s3Key);
     }
   }
+
+
+  @Test
+  @DisplayName("S3 업로드 완료 -> S3의 CSV 행 수, ExportResult.rowCount 일치 -> 성공 후 로컬 파일을 삭제")
+  void export_all_tables_parallel_uploads_to_s3_and_cleans_local() {
+    // Given
+    LocalDate targetDate = LocalDate.now().minusDays(1);
+
+    // When
+    lastResults = assertDoesNotThrow(() -> orchestrator.exportAllFailFastParallel(targetDate));
+
+    // Then
+    assertThat(lastResults).isNotEmpty();
+
+    // S3에 실제 업로드 되었는지 + 내용(행수) 검증 + 로컬 cleanup 검증
+    for (ExportResult result : lastResults.values()) {
+      String fileName = ExportFileName.of(result.table().filePrefix(), result.date()).toFileName();
+
+      // 1) 로컬 파일은 성공 후 삭제되어야 함
+      Path localFinalPath = Path.of(localStorage.resolve(fileName));
+      assertThat(Files.exists(localFinalPath))
+        .as("성공 후 로컬 파일이 남아있으면 안 됩니다: %s", localFinalPath)
+        .isFalse();
+
+      // 2) S3 객체 존재 + 내용(행수) 검증
+      String key = s3Storage.resolve(fileName);
+
+      String body = s3Client.getObjectAsBytes(GetObjectRequest.builder()
+          .bucket(props.s3Bucket())
+          .key(key)
+          .build())
+        .asUtf8String();
+
+      long lineCount = countLines(body); // header 포함 라인수
+      assertThat(lineCount)
+        .as("CSV는 최소 헤더 1줄이 있어야 합니다. table=%s key=%s", result.table(), key)
+        .isGreaterThanOrEqualTo(1);
+
+      long dataRowCount = lineCount - 1; // 헤더 제외
+      assertThat(dataRowCount)
+        .as("S3 CSV 행 수와 ExportResult.rowCount 불일치. table=%s key=%s", result.table(), key)
+        .isEqualTo(result.rowCount());
+    }
+  }
+
+  @Test
+  @DisplayName("S3 업로드 결과가 listBaseFiles에 반영된다(파일명 기준)")
+  void all_exports_s3_list_contains_files() throws IOException {
+    LocalDate testDate = LocalDate.now().minusDays(1);
+
+    lastResults = assertDoesNotThrow(() -> orchestrator.exportAllFailFastParallel(testDate));
+    assertThat(lastResults).isNotEmpty();
+
+    // S3 prefix 아래 파일명 리스트에 포함되는지 확인
+    var s3Files = s3Storage.listBaseFiles();
+
+    for (ExportResult result : lastResults.values()) {
+      String fileName = ExportFileName.of(result.table().filePrefix(), result.date()).toFileName();
+      assertThat(s3Files)
+        .as("S3 prefix 아래 파일이 존재하지 않습니다: %s", fileName)
+        .contains(fileName);
+    }
+  }
+
+  private static long countLines(String text) {
+    try (BufferedReader br = new BufferedReader(new StringReader(text))) {
+      return br.lines().count();
+    } catch (IOException e) {
+      // StringReader는 IOException 거의 안 나지만 시그니처 맞추기
+      throw new IllegalStateException(e);
+    }
+  }
+
 }


### PR DESCRIPTION
> 독감 이슈로 늦은 PR 작성 죄송합니다..

### ⛓️‍💥 Issue Number
<!---- 목적 -->
<!---- Resolves: #(Isuue Number) -->
- close #139

  <br/>

### 🔎 Summary
<!---- 변경된 내용에 대해 자세히 설명해주세요. -->
- #69 에서 적용했던 비동기의 성능을 동기와 비교하였어요.
해당 PR를 작성중에는 개발 기간이 부족하여 내용이 부족했었기 때문에 해당 PR에서 내용을 추가하겠습니다.

- S3 업로드 성능 개선
OutputStream을 대체하여 fromFile 방식으로 수정 후 성능을 실제 테스트를 통해 내용을 작성합니다.

  <br/>

## 동기 vs 비동기
Fail-Fast와 롤백 정책, 자료 구조를 최대한 유지한 후 사용한 테스트 결과입니다.

  <br/>

### 🪜측정 방법 (5회 시행)
테스트를 위한 DB의 값 추가
- project(10,000건 약 6.2M)
- logistics(10,000건 약 5.5MB), logistics_item(25,000건 약 750KB)
- inventory(10,000건 약 5.5MB), inventory_item(25,000건 약 700 KB)
- item(25,000건 약 600 KB)

  <br/>

### 🚩테스트 종합 요약
| 항목 | 동기(Synchronous) | 비동기(Asynchronous) | 성능 향샹 |
| -------------------- | --------------------: | -----------------: | -----------------: |
| 평균 소요 시간 |  588.6 ms | 399.8 ms | 약 32.1% 단축 |
| 최저(Best) 시간 | 570.0 ms | 384.0 ms | - |
| 최고(Worst) 시간 | 612.0 ms | 439.0 ms | - |
| 변동 편차(Range) | 42.0 ms | 55.0 ms | - |

### 🔎테이블별 상세 소요 시간 비교 (평균값 기준)
각 테이블은 총 105,000개의 행(Rows)을 처리하며, 방식에 따라 개별 처리 시간이 다르게 나타납니다.
| 테이블명 (Rows 수) | 동기 평균 (ms) | 비동기 평균 (ms) | 특징 분석 |
| -------------------- | --------------------: | -----------------: | -----------------: |
| INVENTORY_ITEM (25k) |	114.6 |	373.0 |	비동기 시 오버헤드 발생 |
| INVENTORY (10k) |	110.0 | 	384.0 |	- |
| ITEM (25k) |	58.8 | 	316.2 |	- |
| LOGISTICS_ITEM (25k) | 	57.2 | 	357.2 |	- |
| LOGISTICS (10k) |	156.4 |	386.6 |	동기 시 가장 큰 병목|
| PROJECT (10k) |	88.4 |	355.0 |	- |

비동기 방식에서 각 테이블의 elapsedMs가 더 높게 나타나는 이유는 동시 다발적인 리소스(CPU/DB Connection) 점유로 인해 개별 스레드의 처리 속도는 낮아지기 때문입니다. 하지만 전체 총 소요 시간은 병렬 처리 덕분에 훨씬 짧아집니다.


### 📊 회차별 데이터 분석 요약

[동기 방식 (Sync)]
- 안정성: 모든 회차에서 570ms~612ms 사이를 유지하며 매우 규칙적인 흐름을 보입니다.
- 구조: 순차적 처리(Sequential)이므로 Total = Table A + Table B + ...의 공식을 정확히 따릅니다.
- 병목: LOGISTICS 테이블 처리가 항상 150ms 내외로 가장 느려, 전체 시스템의 속도를 지연시키는 주요 원인이 됩니다.
<img width="1388" height="320" alt="image" src="https://github.com/user-attachments/assets/5519a565-e495-4728-a83e-78f141962863" />

[비동기 방식 (Async)]
- 효율성: 동기 방식에서 1~2개 테이블을 처리할 시간에 6개 테이블의 처리를 모두 종료됩니다.
- 로그 패턴: 로그가 찍히는 순서가 매 회차 다릅니다. 이는 먼저 완료된 작업이 즉시 반환되는 Non-blocking입니다.
- 최적 성능: 4회차에서 384ms라는 속도를 기록했습니다.
<img width="972" height="295" alt="image" src="https://github.com/user-attachments/assets/d3084338-9261-4036-a99d-d49acc8e6693" />


## 결론
성능 임계점(Throughput): 동기 방식은 응답 시간(Latency)은 짧으나 처리량(Throughput)이 낮습니다. 비동기 방식은 개별 작업의 Latency는 증가했으나, 전체 작업을 동시에 끝내버림으로써 처리량을 약 1.47배 향상시켰습니다.

  <br/>
  
## 🤖 S3 업로드 성능 개선
S3 업로드를 메모리 적재(ByteArrayOutputStream → fromBytes) 방식에서 
파일 스트리밍(RequestBody.fromFile) 방식으로 전환하여 업로드 구간에서 발생하는 
대용량 byte[] 할당/복사 및 GC 부담을 줄이고 Fail-Fast + 롤백(성공한 객체만 추적) 원칙을 유지했습니다.

  <br/>

### 💭 배경/문제 (Before)
현재 업로드 흐름은 로컬 파일 전체를 ByteArrayOutputStream에 적재한 뒤 (정확히는 close 시점)
putObject(fromBytes)로 한 번에 전송하는 구조였습니다.

메모리/GC 관점에서의 구조적 비용
| 항목                   |                          메모리 적재(BAOS + fromBytes) |  파일 스트리밍(fromFile) |
| -------------------- | -----------------------------------------------------: | -----------------: |
| 업로드 중 Heap 추가 사용량    |                                          파일 크기 N에 비례 | 일정 버퍼 수준(상대적으로 작음) |
| 추가 복사 비용             | `toByteArray()` 호출 시 동일 크기 N 복사본 추가 → 최악 ~2N |  없음(파일 → 네트워크 스트림) |
| GC/Stop-the-world 위험 |                            대용량 배열 할당/해제가 반복되면 멈출 가능성↑ |      대용량 배열 할당 빈도↓ |

  <br/>

### ✨ 개선 내용 (After)
| 구분           | 변경 전                      | 변경 후                                              |
| ------------ | ------------------------- | ------------------------------------------------- |
| 업로드 방식       | BAOS 적재 후 `fromBytes` 업로드 | 로컬 완성 CSV를 `RequestBody.fromFile(Path)`로 스트리밍 업로드 |
| Fail-Fast 유지 | 1개라도 실패 시 전체 실패           | 동일                                                |
| 롤백           | 로컬 파일/업로드 객체 정리           |  동일        |

  <br/>

### 🪜측정 방법
테스트를 위한 DB의 값 추가
- project(10,000건 약 6.2MB)
- logistics(10,000건 약 5.5MB), logistics_item(25,000건 약 750KB)
- inventory(10,000건 약 5.5MB), inventory_item(25,000건 약 700 KB)
- item(25,000건 약 600 KB)

업로드 1건마다 아래를 로그로 남겼음:
- JVM-CURR(before/after) : 업로드 전후 현재 사용량(used)
- JVM-PEAK(peak-one-upload) : 업로드 1건 동안의 피크(peak)
> resetPeakUsage()를 업로드 1건 시작 시점마다 수행해 “건별 peak”로 비교 가능하게 구성.
<img width="2013" height="647" alt="수정전 1차 (2)" src="https://github.com/user-attachments/assets/e8f4e4e9-ebe7-418d-b557-e92c61fe5c5c" />

  <br/>

### 🔎실측 결과 요약 (1차 + 2차 재실험)
핵심 지표 정의
Heap Drift (MB): 첫 업로드 직전 heap → 마지막 업로드 직후 heap 변화량
→ “업로드가 진행될수록 heap used가 누적되는가?”를 보여주는 지표

Peak Growth (MB): 첫 업로드 peak → 마지막 업로드 peak 변화량
→ “작업 진행 중 피크가 얼마나 더 커지는가?”를 보여주는 지표

### 📊 1차/2차 비교 테이블
실험 | 방식 | Peak (첫 업로드 → 마지막) | Peak Growth | Heap (첫 before → 마지막 after) | Heap Drift
-- | -- | -- | -- | -- | --
1차 | Buffering(OutputStream/BAOS 계열) | 322.25 → 454.81 | +132.56MB | 180.77 → 312.77 | +132.00MB
1차 | Streaming(fromFile) | 506.63 → 510.10 | +3.47MB | 344.15 → 368.15 | +24.00MB
2차 | Buffering(OutputStream/BAOS 계열) | 386.16 → 520.78 | +134.62MB | 248.05 → 380.05 | +132.00MB
2차 | Streaming(fromFile) | 398.44 → 401.95 | +3.51MB | 234.76 → 260.76 | +26.00MB

결론적으로, fromFile 스트리밍 방식은 업로드 진행 중 피크 증가가 거의 없고,
Buffering 방식은 업로드가 진행될수록 heap used/peak가 누적 상승하는 패턴이 1차·2차 모두에서 재현됨.

  <br/>

### ⏰ 실행 시간 측면의 유의미한 차이 미비
테스트 결과, 업로드 방식(Streaming vs Memory-heavy)에 따른 실행 시간 차이는 약 8,400ms 범위 내에서 불규칙하게 발생하였습니다. 두 방식 모두 환경에 따라 4,800ms ~ 16,700ms 사이의 분포를 보이며 특정 방식이 압도적으로 빠르다는 결론을 내리기에는 통계적 유의성이 부족한 것으로 판단됩니다.

소요 시간의 변동성은 코드 내부 로직보다는 다음과 같은 인프라 및 외부 요인에 의해 지배적인 영향을 받는 것으로 분석됩니다.
- 네트워크 I/O 및 대역폭: 로컬 파일의 전송 속도 자체가 네트워크 환경
- S3 인증 및 세션 핸드쉐이크: AWS SDK의 인증 과정 및 초기 커넥션 생성 시간이 전체 Latency
- 환경적 변수: 동일 환경 내에서도 매 실행 시마다 발생하는 네트워크 지연(Jitter)이 로직 변경을 통한 개선분보다 더 크게 작용

  <br/>

### 2차 상세(파일별)

2차 Buffering(OutputStream/Files.copy 경로)
| 파일             | Heap Before | Heap After |      ΔHeap | Peak Total |
| -------------- | ----------: | ---------: | ---------: | ---------: |
| logistics_item |      248.05 |     250.05 |      +2.00 |     386.16 |
| item           |      272.05 |     276.05 |      +4.00 |     416.40 |
| inventory_item |      276.05 |     280.05 |      +4.00 |     420.49 |
| inventory      |      282.05 |     304.05 | **+22.00** |     444.64 |
| project        |      318.05 |     340.05 | **+22.00** |     480.70 |
| logistics      |      358.05 |     380.05 | **+22.00** |     520.78 |

업로드가 진행될수록 heap after가 계속 상승(누적) → 최종 heap drift +132MB

2차 Streaming(putObject + RequestBody.fromFile)
| 파일             | Heap Before | Heap After |      ΔHeap | Peak Total |
| -------------- | ----------: | ---------: | ---------: | ---------: |
| item           |      234.76 |     256.76 | **+22.00** |     398.44 |
| inventory_item |      256.76 |     256.76 |      +0.00 |     398.63 |
| logistics_item |      256.76 |     258.76 |      +2.00 |     400.72 |
| inventory      |      258.76 |     258.76 |      +0.00 |     399.74 |
| project        |      258.76 |     260.76 |      +2.00 |     401.81 |
| logistics      |      260.76 |     260.76 |      +0.00 |     401.95 |

첫 업로드에서만 증가(초기화/워밍업 비용 가능), 이후 heap/peak가 거의 고정 → peak growth +3.51MB

  <br/>

## 결론
2차 결과까지 종합해 볼 때 uploadFile 방식이 우수합니다. OutputStream 방식은 현재 코드상에서 메모리 누수(Leak)가 있거나 처리 후 자원 해제가 즉각적으로 이루어지지 않는 구조적인 결함이 예상됩니다.
반면 uploadFile 방식은 Java의 NIO나 라이브러리 차원에서의 최적화(Direct Buffer 재사용 등)가 잘 적용되어 있어. 대규모 배치 작업이나 다량의 파일 업로드 시 시스템 전체의 안정성을 보장해 줍니다.

  <br/>

### ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링
 
<br/>

### ✅ PR 체크 리스트
- PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 리뷰어 설정을 했나요?
- [x] Lables를 설정했나요?
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
- [x] test workflow가 정상적으로 작동했습니다.
- [x] 병합 위치가 올바른 브랜치인지 확인하셨나요?